### PR TITLE
Add message block changes

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -46,6 +46,17 @@ module Lita
           call_api("im.list")
         end
 
+        def send_blocks(room_or_user, blocks)
+          call_api(
+            "chat.postMessage",
+            as_user: true,
+            unfurl_links: @config.unfurl_links,
+            unfurl_media: @config.unfurl_media,
+            channel: room_or_user.id,
+            blocks: MultiJson.dump(blocks.map(&:to_hash))
+          )
+        end
+
         def send_attachments(room_or_user, attachments)
           call_api(
             "chat.postMessage",

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -23,6 +23,10 @@ module Lita
           api.send_attachments(target, Array(attachments))
         end
         alias_method :send_attachment, :send_attachments
+
+        def send_blocks(target, blocks)
+          api.send_blocks(target.room_object, blocks)
+        end
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Jared Quick <jared.quick@salesforce.com>

Add the option for sending blocks via the chat services